### PR TITLE
Add ggtime to attached packages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,6 +38,7 @@ Imports:
     fable (>= 0.3.0),
     feasts (>= 0.1.7),
     ggplot2 (>= 3.1.1),
+    ggtime,
     lubridate (>= 1.7.4),
     purrr (>= 0.2.4),
     rstudioapi (>= 0.7),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # fpp3 (development version)
 
+  * Added ggtime to the attached packages
+
 # fpp3 1.0.2
 
   * Removed fabletools from imports

--- a/R/attach.R
+++ b/R/attach.R
@@ -6,6 +6,7 @@ core <- c(
   "tidyr",
   "lubridate",
   "ggplot2",
+  "ggtime",
   "tsibble",
   "tsibbledata",
   "feasts",


### PR DESCRIPTION
The issues with function and S3 method masking has been resolved, and so ggtime is ready to be bundled with the other attached packages. A fpp3 release should occur after the release of:
- [ ] feasts v0.5.0
- [ ] fabletools v0.6.0
- [ ] ggtime v0.2.0

*Note: these are not hard dependencies, but timing the fpp3 release after they are updated would speed up user migration.*

Additionally, the S3 masking of `as_tibble.grouped_df` by tsibble has been fixed in https://github.com/tidyverts/tsibble/commit/2917140d16c2562a8a327314db494b12ef7d6642. This should remove all masking warnings on package load.