### PR TITLE
Removes commented-out remotes installation

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -36,7 +36,6 @@ You can install the **development** version from
 [Github](https://github.com/robjhyndman/fpp3)
 
 ```{r eval = FALSE}
-# install.packages("remotes")
 pak::pak("robjhyndman/fpp3")
 ```
 


### PR DESCRIPTION
Removes the commented-out `install.packages("remotes")` line, as the recommended installation method is now `pak::pak("robjhyndman/fpp3")`.